### PR TITLE
chore: promote jx3-python-http-example to version 0.0.4

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-python-http-example/jx3-python-http-example-jx3-python-http-example-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-python-http-example/jx3-python-http-example-jx3-python-http-example-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-python-http-example-jx3-python-http-example
   labels:
     draft: draft-app
-    chart: "jx3-python-http-example-0.0.2"
+    chart: "jx3-python-http-example-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx3-python-http-example'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: jx3-python-http-example-jx3-python-http-example
       containers:
         - name: jx3-python-http-example
-          image: "10.97.10.152/vmgnud/jx3-python-http-example:0.0.2"
+          image: "10.97.10.152/vmgnud/jx3-python-http-example:0.0.4"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.2
+              value: 0.0.4
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/jx3-python-http-example/jx3-python-http-example-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-python-http-example/jx3-python-http-example-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-python-http-example
   labels:
-    chart: "jx3-python-http-example-0.0.2"
+    chart: "jx3-python-http-example-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx3-python-http-example'

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@
 		    </tr>
 	    <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> jx3-python-http-example </a></td>
-	      <td>0.0.2</td>
+	      <td>0.0.4</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -115,13 +115,13 @@
   path: helmfiles/jx-staging/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.2
+    appVersion: 0.0.4
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-01-09T14:41:47Z"
+    firstDeployed: "2022-01-09T16:32:26Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-01-09T14:41:47Z"
+    lastDeployed: "2022-01-09T16:32:26Z"
     name: jx3-python-http-example
     repositoryName: dev
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
     resourcePath: config-root/namespaces/jx-staging/jx3-python-http-example
-    version: 0.0.2
+    version: 0.0.4

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/jx3-python-http-example
-  version: 0.0.2
+  version: 0.0.4
   name: jx3-python-http-example
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote jx3-python-http-example to version 0.0.4

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
